### PR TITLE
Build static binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ OUT := debugcc
 CC=aarch64-linux-gnu-gcc
 
 CFLAGS := -O2 -Wall -g
-LDFLAGS := 
+LDFLAGS := -static -static-libgcc
 prefix := /usr/local
 
 SRCS := debugcc.c qcs404.c sdm845.c


### PR DESCRIPTION
Some initramfs don't ship with the standard libraries, statically linking debugcc came in handy for me.