### PR TITLE
debugcc: allow leaf muxes to override measurement function

### DIFF
--- a/debugcc.c
+++ b/debugcc.c
@@ -194,7 +194,10 @@ static void measure(const struct measure_clk *clk)
 
 	mux_prepare_enable(clk->primary, clk->mux);
 
-	clk_rate = measure_default(clk);
+	if (clk->leaf && clk->leaf->measure)
+		clk_rate = clk->leaf->measure(clk);
+	else
+		clk_rate = measure_default(clk);
 
 	mux_disable(clk->primary);
 

--- a/debugcc.h
+++ b/debugcc.h
@@ -35,6 +35,8 @@
 
 #define CORE_CC_BLOCK "core"
 
+struct measure_clk;
+
 struct debug_mux {
 	unsigned long phys;
 	void *base;
@@ -61,6 +63,7 @@ struct debug_mux {
 	unsigned int ahb_mask;
 
 	void (*premeasure)(struct debug_mux *mux);
+	unsigned long (*measure)(const struct measure_clk *clk);
 	void (*postmeasure)(struct debug_mux *mux);
 };
 


### PR DESCRIPTION
MCCC (memory clock controller) uses non-standard measuring process (just
read the rate and return). Provide a way to override default
measurement proces with the leaf cc hook.

This also fixes the issue that muxes will not be disabled for
the clocks that are not turned off (because measure function will return
early for disabled clocks).