### PR TITLE
Implement MCCC measurements for SM8150 and SM8250

### DIFF
--- a/debugcc.c
+++ b/debugcc.c
@@ -186,6 +186,12 @@ static unsigned long measure_default(const struct measure_clk *clk)
 	return raw_count_full;
 }
 
+unsigned long measure_mccc(const struct measure_clk *clk)
+{
+	/* MCCC is always on, just read the rate and return. */
+	return 1000000000000ULL / readl(clk->leaf->base + clk->leaf_mux);
+}
+
 static void measure(const struct measure_clk *clk)
 {
 	unsigned long clk_rate;

--- a/debugcc.h
+++ b/debugcc.h
@@ -87,6 +87,7 @@ struct debugcc_platform {
 int mmap_mux(int devmem, struct debug_mux *mux);
 void mux_enable(struct debug_mux *mux);
 void mux_disable(struct debug_mux *mux);
+unsigned long measure_mccc(const struct measure_clk *clk);
 
 extern struct debugcc_platform msm8936_debugcc;
 extern struct debugcc_platform msm8996_debugcc;

--- a/sm8150.c
+++ b/sm8150.c
@@ -138,6 +138,14 @@ static struct debug_mux npu_cc = {
 	.div_val = 2,
 };
 
+static struct debug_mux mc_cc = {
+	.phys =	0x90b0000,
+	.size = /* 0x54 */ 0x1000,
+	.block_name = "mc",
+
+	.measure = measure_mccc,
+};
+
 static struct debug_mux cpu_cc = {
 	.phys = 0x182a0000,
 	.size = 0x1000,
@@ -247,7 +255,7 @@ static struct measure_clk sm8150_clocks[] = {
 	{ "measure_only_cdsp_clk", &gcc, 0xdb, 0, 0, 2 },
 	{ "measure_only_snoc_clk", &gcc, 0x7 },
 	{ "measure_only_cnoc_clk", &gcc, 0x19 },
-	// { "measure_only_mccc_clk", &gcc, 0xd0, 1, MC_CC, 0xd0 }, // TODO: at 90b0000
+	{ "measure_only_mccc_clk", &gcc, 0xd0, &mc_cc, 0x50 },
 	{ "measure_only_ipa_2x_clk", &gcc, 0x147 },
 	{ "gcc_aggre_noc_pcie_tbu_clk", &gcc, 0x36 },
 	{ "gcc_aggre_ufs_card_axi_clk", &gcc, 0x141 },

--- a/sm8150.c
+++ b/sm8150.c
@@ -217,6 +217,7 @@ static struct measure_clk sm8150_clocks[] = {
 	{ "cam_cc_mclk1_clk", &gcc, 0x55, &cam_cc, 0x2 },
 	{ "cam_cc_mclk2_clk", &gcc, 0x55, &cam_cc, 0x3 },
 	{ "cam_cc_mclk3_clk", &gcc, 0x55, &cam_cc, 0x4 },
+
 	{ "disp_cc_mdss_ahb_clk", &gcc, 0x56, &disp_cc, 0x2b },
 	{ "disp_cc_mdss_byte0_clk", &gcc, 0x56, &disp_cc, 0x15 },
 	{ "disp_cc_mdss_byte0_intf_clk", &gcc, 0x56, &disp_cc, 0x16 },
@@ -250,9 +251,11 @@ static struct measure_clk sm8150_clocks[] = {
 	{ "disp_cc_mdss_rscc_vsync_clk", &gcc, 0x56, &disp_cc, 0x2d },
 	{ "disp_cc_mdss_vsync_clk", &gcc, 0x56, &disp_cc, 0x14 },
 	{ "disp_cc_xo_clk", &gcc, 0x56, &disp_cc, 0x36 },
-	/* TODO: post_div_val and prim_mux_div_val are 2 */
-	// { "measure_only_cdsp_clk", &gcc, 0xdb, 2, GCC, 0xdb, 0x3ff, 0, 0xf, 0, 2, 0x62000, 0x62004, 0x62008 },
-	{ "measure_only_cdsp_clk", &gcc, 0xdb, 0, 0, 2 },
+
+	// { "cpu_cc_debug_mux", &gcc, 0xe8 },
+	// { "cam_cc_debug_mux", &gcc, 0x55 },
+	// { "disp_cc_debug_mux", &gcc, 0x56 },
+	{ "measure_only_cdsp_clk", &gcc, 0xdb, NULL, 0, 2 },
 	{ "measure_only_snoc_clk", &gcc, 0x7 },
 	{ "measure_only_cnoc_clk", &gcc, 0x19 },
 	{ "measure_only_mccc_clk", &gcc, 0xd0, &mc_cc, 0x50 },
@@ -381,6 +384,11 @@ static struct measure_clk sm8150_clocks[] = {
 	{ "gcc_video_axi1_clk", &gcc, 0x4b },
 	{ "gcc_video_axic_clk", &gcc, 0x4c },
 	{ "gcc_video_xo_clk", &gcc, 0x51 },
+	// { "gpu_cc_debug_mux", &gcc, 0x162 },
+	// { "mc_cc_debug_mux", &gcc, 0xd0 },
+	// { "npu_cc_debug_mux", &gcc, 0x180 },
+	// { "video_cc_debug_mux", &gcc, 0x57 },
+
 	{ "gpu_cc_ahb_clk", &gcc, 0x162, &gpu_cc, 0x10 },
 	{ "gpu_cc_cx_apb_clk", &gcc, 0x162, &gpu_cc, 0x14 },
 	{ "gpu_cc_cx_gmu_clk", &gcc, 0x162, &gpu_cc, 0x18 },
@@ -394,6 +402,7 @@ static struct measure_clk sm8150_clocks[] = {
 	{ "measure_only_gpu_cc_cx_gfx3d_clk", &gcc, 0x162, &gpu_cc, 0x1a },
 	{ "measure_only_gpu_cc_cx_gfx3d_slv_clk", &gcc, 0x162, &gpu_cc, 0x1b },
 	{ "measure_only_gpu_cc_gx_gfx3d_clk", &gcc, 0x162, &gpu_cc, 0xb },
+
 	{ "npu_cc_armwic_core_clk", &gcc, 0x180, &npu_cc, 0x4 },
 	{ "npu_cc_bto_core_clk", &gcc, 0x180, &npu_cc, 0x12 },
 	{ "npu_cc_bwmon_clk", &gcc, 0x180, &npu_cc, 0xf },
@@ -408,11 +417,13 @@ static struct measure_clk sm8150_clocks[] = {
 	{ "npu_cc_npu_cpc_clk", &gcc, 0x180, &npu_cc, 0x3 },
 	{ "npu_cc_perf_cnt_clk", &gcc, 0x180, &npu_cc, 0x10 },
 	{ "npu_cc_xo_clk", &gcc, 0x180, &npu_cc, 0x11 },
+
 	{ "video_cc_iris_ahb_clk", &gcc, 0x57, &video_cc, 0x7 },
 	{ "video_cc_mvs0_core_clk", &gcc, 0x57, &video_cc, 0x3 },
 	{ "video_cc_mvs1_core_clk", &gcc, 0x57, &video_cc, 0x5 },
 	{ "video_cc_mvsc_core_clk", &gcc, 0x57, &video_cc, 0x1 },
 	{ "video_cc_xo_clk", &gcc, 0x57, &video_cc, 0x8 },
+
 	{ "l3_clk", &gcc, 0xe8, &cpu_cc, 0x46, 16 },
 	{ "pwrcl_clk", &gcc, 0xe8, &cpu_cc, 0x44, 16 },
 	{ "perfcl_clk", &gcc, 0xe8, &cpu_cc, 0x45, 16 },

--- a/sm8250.c
+++ b/sm8250.c
@@ -138,13 +138,13 @@ static struct debug_mux video_cc = {
 	.div_val = 3,
 };
 
-// static struct debug_mux mc_cc = {
-// 	.phys =	0x90ba000,
-// 	.size = /* 0x54 */ 0x1000,
-// 	.block_name = "mc",
+static struct debug_mux mc_cc = {
+	.phys =	0x90ba000,
+	.size = /* 0x54 */ 0x1000,
+	.block_name = "mc",
 
-// 	/* TODO: Requires custom readback from https://github.com/andersson/debugcc/pull/15 */
-// };
+	.measure = measure_mccc,
+};
 
 static struct debug_mux apss_cc = {
 	.phys =	0x182a0000,
@@ -477,7 +477,7 @@ static struct measure_clk sm8250_clocks[] = {
 	{ "video_cc_sleep_clk", &gcc, 0x57, &video_cc, 0xc },
 	{ "video_cc_xo_clk", &gcc, 0x57, &video_cc, 0xb },
 
-	// { "measure_only_mccc_clk", &gcc, 0xd1, &mc_cc },
+	{ "measure_only_mccc_clk", &gcc, 0xd1, &mc_cc, 0x50 },
 
 	{ "measure_only_apcs_gold_post_acd_clk", &gcc, 0xe7, &apss_cc, 0x25, /* TODO: Are these pre_div_vals? */ 8 },
 	{ "measure_only_apcs_goldplus_post_acd_clk", &gcc, 0xe7, &apss_cc, 0x61, /* TODO: Are these pre_div_vals? */ 8 },


### PR DESCRIPTION
Depends on #15 and #16

```console
sony-pdx206-generic@~$ sudo ./debugcc -p sm8250 measure_only_mccc_clk
                             measure_only_mccc_clk: 2739.726027MHz (2739726027Hz)

sony-bahamut-generic@~$ sudo ./debugcc -p sm8150 -b mc -a
                             measure_only_mccc_clk: 2096.436058MHz (2096436058Hz)
```
